### PR TITLE
Fix UI overlap in Full Scan dialog

### DIFF
--- a/Auctionator/Auctionator.xml
+++ b/Auctionator/Auctionator.xml
@@ -1240,7 +1240,7 @@
 					<Anchors><Anchor point="TOPLEFT"><Offset x="150" y="-105"/></Anchor></Anchors>
 				</FontString>
 				<FontString name="Atr_FullScanStatus" inherits="GameFontNormal" text="">
-					<Anchors><Anchor point="TOPLEFT"><Offset x="27" y="-140"/></Anchor></Anchors>
+					<Anchors><Anchor point="TOPLEFT"><Offset x="27" y="-130"/></Anchor></Anchors>
 				</FontString>
 			</Layer>
 
@@ -1250,7 +1250,7 @@
 			
 			<Button name="Atr_FullScanDone" inherits="UIPanelButtonTemplate" text="DONE">
 				<Size><AbsDimension x="80" y="22"/>	</Size>
-				<Anchors><Anchor point="TOPRIGHT"><Offset><AbsDimension x="-30" y="-140"/></Offset></Anchor></Anchors>
+				<Anchors><Anchor point="TOPRIGHT"><Offset><AbsDimension x="-30" y="-155"/></Offset></Anchor></Anchors>
 				<Scripts>
 					<OnClick>
 						Atr_FullScanFrame:Hide();


### PR DESCRIPTION
## Description
This PR fixes a UI overlap issue in the Full Scan dialog where the status text ("Stopped after 20s...") was overlapping with the "Start Scanning" and "Done" buttons.

## Problem
As shown in the screenshots, when the scan stops after the 20-second timeout, the status message appears on the same horizontal line as the buttons, causing text to overlap and reducing readability.

## Solution
Adjusted the vertical positioning of UI elements:
- Moved the status text (`Atr_FullScanStatus`) from `y=-140` to `y=-130` 
- Moved the Done button (`Atr_FullScanDone`) from `y=-140` to `y=-155`

This creates proper spacing (25 pixels) between the status text and buttons.

## Testing
The change has been tested and confirmed to:
- Prevent text-button overlap
- Maintain proper UI layout
- Work correctly during both normal scans and timeout scenarios