### PR TITLE
Fix: Remove window resizing when switching between tabs

### DIFF
--- a/Auctionator/Auctionator.lua
+++ b/Auctionator/Auctionator.lua
@@ -116,7 +116,6 @@ local gSB_Widgets = {};           -- dynamic frames created under Atr_SB_Content
 
 -- SELL tab enlarged layout state
 local gSellLayoutExpandedApplied = false;
-local gAF_OrigScale = nil;
 local gHB_OrigPoint = nil;           -- Atr_HeadingsBar original anchor
 local gSF_OrigPoint = nil;           -- AuctionatorScrollFrame original anchor
 
@@ -1427,12 +1426,6 @@ end
 function Atr_ApplySellExpandedLayout()
     if (gSellLayoutExpandedApplied) then return; end
 
-    -- Scale up the entire AuctionFrame
-    if (AuctionFrame) then
-        gAF_OrigScale = gAF_OrigScale or AuctionFrame:GetScale();
-        AuctionFrame:SetScale((gAF_OrigScale or 1) * 1.15);
-    end
-
     -- Re-anchor the inventory browser below the image in the center panel
     if (Atr_SellBrowser and Atr_RecommendItem_Tex) then
         Atr_SellBrowser:ClearAllPoints();
@@ -1468,11 +1461,6 @@ end
 
 function Atr_ResetSellExpandedLayout()
     if (not gSellLayoutExpandedApplied) then return; end
-
-    -- Restore AuctionFrame scale
-    if (AuctionFrame and gAF_OrigScale) then
-        AuctionFrame:SetScale(gAF_OrigScale);
-    end
 
     -- Restore headings and scroll positions
     if (gHB_OrigPoint) then RestorePoint(Atr_HeadingsBar, gHB_OrigPoint); end


### PR DESCRIPTION
## Summary
- Removes the 1.15x window scaling that occurred when selecting the SELL tab
- Prevents the auction house window from resizing when switching between tabs
- Keeps all other SELL tab functionality intact

## Problem
When switching between tabs in the auction house, particularly between SELL and MORE tabs, the window would resize. This was caused by the SELL tab applying a 1.15x scale to the entire AuctionFrame.

## Solution
Removed the scaling code from both `Atr_ApplySellExpandedLayout()` and `Atr_ResetSellExpandedLayout()` functions. The window now maintains a consistent size across all tabs.

## Testing
1. Open the Auction House
2. Click through all tabs (Browse, Bids, Auctions, Buy, Sell, More)
3. Verify the window maintains the same size
4. Confirm all SELL tab features still work (inventory browser, item listing, etc.)

## Changes
- Removed AuctionFrame scaling logic from SELL tab
- Removed unused `gAF_OrigScale` variable
- All other SELL tab features remain unchanged